### PR TITLE
Upgrade most dependency to 1.0 and add most to devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 
 lib/
 coverage/
+typings/

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 coverage/
+typings/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test-ci": "npm run lib && npm run lint && npm run test-node && testem ci",
     "dist": "rimraf dist/ && mkdirp dist && npm run lib && browserify lib/index.js -t babelify -t browserify-shim --standalone mostProxy --exclude most --outfile dist/most-proxy.js && uglifyjs dist/most-proxy.js -o dist/most-proxy.min.js",
     "postdist": "git add dist/ && git commit -m 'chore(dist): build dist/'",
+    "prelib": "typings install env~es2015-promise --global",
     "lib": "rimraf lib/ && mkdirp lib/ && tsc",
     "prepublish": "npm run lib",
     "prerelease": "npm run doc && npm run dist && npm run changelog",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Circular Dependencies for most.js",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "doc": "typedoc --excludeNotExported --out doc/ --module commonjs --target ES5 --name 'Most Proxy' src/index.ts",
     "postdoc": "git add doc/ && git commit -m 'chore(docs): build doc/'",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
     "validate-commit-msg": "^2.6.1"
   },
   "peerDependencies": {
-    "most": "^0.19.7"
+    "most": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ghooks": "^1.2.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
+    "most": "^1.0.0",
     "power-assert": "^1.4.1",
     "rimraf": "^2.5.2",
     "testem": "^1.7.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "tabSize": 2
   },
    "files": [
+     "typings/index.d.ts",
      "src/index.ts"
    ]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,7 @@
 {
-  "name": "most-subject",
-  "dependencies": {
+  "name": "most-proxy",
+  "dependencies": {},
+  "globalDependencies": {
+    "es2015-promise": "registry:env/es2015-promise#1.0.0+20160526151700"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
-{
-  "name": "most-proxy",
-  "dependencies": {},
-  "globalDependencies": {
-    "es2015-promise": "registry:env/es2015-promise#1.0.0+20160526151700"
-  }
-}


### PR DESCRIPTION
This PR upgrades the most.js peerDependency to 1.0.0 and adds a devDependency for the same. This is appropriate because `most` is indeed a development dependency of `most-proxy`, and it fixes an issue with running `npm install` and running into errors when npm install hooks try to build before `most` is installed.

The `Promise` type was removed from `most` type definitions in most 1.0, and most-proxy could not build without one. This PR installs a Promise type for development but is careful that the type will not be published with the package, allowing users to provide a compatible Promise type of their choice.

Thanks for most-proxy!